### PR TITLE
Remove unnecessary computation

### DIFF
--- a/src/Executables/FINALIZE.bat
+++ b/src/Executables/FINALIZE.bat
@@ -36,9 +36,7 @@ if "%hardDrive%"=="HDD" (
 
 echo Configuring memory...
 
-for /f "tokens=2 delims==" %%a in ('wmic os get TotalVisibleMemorySize /format:value') do set "memTemp=%%a"
-set /a "mem=%memTemp% + 1024000"
-reg add "HKLM\SYSTEM\CurrentControlSet\Control" /v "SvcHostSplitThresholdInKB" /t REG_DWORD /d "%mem%" /f >NUL
+reg add "HKLM\SYSTEM\CurrentControlSet\Control" /v "SvcHostSplitThresholdInKB" /t REG_DWORD /d "4294967295" /f >NUL
 reg add "HKLM\SOFTWARE\Policies\Microsoft\InputPersonalization" /v "AllowInputPersonalization" /t REG_DWORD /d "0" /f >NUL
 
 for /f "usebackq tokens=2 delims=\" %%a in (`reg query "HKEY_USERS" ^| findstr /r /x /c:"HKEY_USERS\\S-.*" /c:"HKEY_USERS\\AME_UserHive_[^_]*"`) do (


### PR DESCRIPTION
In the existing code, it is clear that the intention is to set the ``SvcHostSplitThresholdInKB`` threshold to a value larger than the installed memory so that ``svchost.exe`` instances are combined. Since the registry key is a threshold, the value can be set to the maximum DWORD value (0xFFFFFFFF/4294967295) to achieve the same outcome. No calculations required.