### PR TITLE
IFEO disable FeatureLoader.exe

### DIFF
--- a/src/Configuration/features/revision/registry/configure-ifeo.yml
+++ b/src/Configuration/features/revision/registry/configure-ifeo.yml
@@ -9,6 +9,8 @@ actions:
   - !registryValue: {path: 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\AggregatorHost.exe', value: 'Debugger', type: REG_SZ, data: '%windir%\System32\taskkill.exe'}
     # === Webcam Telemetry
   - !registryValue: {path: 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\DeviceCensus.exe', value: 'Debugger', type: REG_SZ, data: '%windir%\System32\taskkill.exe'}
+    # === Microsoft PC Manager spread
+  - !registryValue: {path: 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\FeatureLoader.exe', value: 'Debugger', type: REG_SZ, data: '%windir%\System32\taskkill.exe'}
     # === Change CPU priority to Below Normal
     # ------> if no issues will be reported, then also change IO priority
     #  1 Idle


### PR DESCRIPTION
In the process of using ReviOS, I found that Microsoft still pops up the advertisement of Microsoft PC Manager.

![pop-up window similar to](https://img.lancdn.com/landian/2023/05/98949-2.png)
The file path of the pop-up advertisement is ```C:\ProgramData\Windows Master Setup\FeatureLoader.exe```

According to network search, this file may have been generated by an automatic update of Microsoft Edge, but since ReviOS removed Edge, and I do not have Edge installed, I am not sure how the file appeared on the system.

But I'm pretty sure that no one wants to see ads, so I suggest disable this program via IFEO.