### PR TITLE
Correctly updating ReviOS version in `winver`

### DIFF
--- a/src/Configuration/features/revision/revert.yml
+++ b/src/Configuration/features/revision/revert.yml
@@ -22,6 +22,8 @@ actions:
   - !registryValue: { path: 'HKCU\SOFTWARE\Policies\Microsoft\Internet Explorer\Privacy', value: 'ClearBrowsingHistoryOnExit', operation: delete }
   - !registryValue: { path: 'HKLM\SOFTWARE\Policies\Microsoft\Internet Explorer\Privacy', value: 'ClearBrowsingHistoryOnExit', operation: delete }
   
-
   # https://github.com/meetrevision/playbook/issues/27
   - !run: {exe: 'netsh', args: 'int tcp set supplemental internet congestionprovider=default', showOutput: false, showError: false}
+
+  # https://github.com/meetrevision/playbook/pull/31
+  - !registryValue: { path: 'HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion', value: 'RegisteredOrganisation', operation: delete }

--- a/src/Executables/FINALIZE.cmd
+++ b/src/Executables/FINALIZE.cmd
@@ -6,11 +6,11 @@ if %build% gtr 19045 ( set "w11=true" )
 if not defined w11 (
 	bcdedit /set description "ReviOS 10 %version%" >NUL 2>nul
   reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OEMInformation" /v "Model"  /t REG_SZ /d "ReviOS 10 %version%" /f >NUL 2>nul
-  reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion" /v "RegisteredOrganisation" /t REG_SZ /d "ReviOS 10 %version%" /f >NUL 2>nul
+  reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion" /v "RegisteredOrganization" /t REG_SZ /d "ReviOS 10 %version%" /f >NUL 2>nul
 ) else (
 	bcdedit /set description "ReviOS 11 %version%" >NUL 2>nul
   reg add "HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OEMInformation" /v "Model"  /t REG_SZ /d "ReviOS 11 %version%" /f >NUL 2>nul
-  reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion" /v "RegisteredOrganisation" /t REG_SZ /d "ReviOS 11 %version%" /f >NUL 2>nul
+  reg add "HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion" /v "RegisteredOrganization" /t REG_SZ /d "ReviOS 11 %version%" /f >NUL 2>nul
 
   :: Credits to Garlin for the idea
   PowerShell -NonInteractive -NoLogo -NoP -C "& { $Cbs = \"$env:SystemRoot\\SystemApps\\MicrosoftWindows.Client.CBS_cw5n1h2txyewy\"; $Manifest = Join-Path $Cbs 'appxmanifest.xml'; takeown /a /f $Manifest; icacls $Manifest /grant Administrators:F; $ReviManifest = Join-Path $Cbs \"appxmanifest.xml.revi\"; if (!(Test-Path $ReviManifest)) { Copy-Item -Path $Manifest -Destination $ReviManifest -Force; Remove-Item $Manifest -Force }; [xml]$xml = Get-Content -Path \"$Cbs\\appxmanifest.xml.revi\" -Raw; $applicationNode = $xml.Package.Applications.Application | Where-Object { $_.Id -eq 'WebExperienceHost' }; if ($applicationNode -ne $null) { $xml.Package.Applications.RemoveChild($applicationNode) } $xml.Save($Manifest) }"


### PR DESCRIPTION
ReviOS 23.08 and before did this right (using the ISO version), however the playbook version has typo, resulting in not displaying the right version (or just showing `org name` if patching from clean Windows installation) in `winver`.
![image](https://github.com/meetrevision/playbook/assets/29724654/65ccab89-134e-4968-bebb-4bbf9d529241)
![image](https://github.com/meetrevision/playbook/assets/29724654/a91f8a6d-7202-4a5f-a680-9082d1c3c6cd)
