### PR TITLE
perf: improve file explorer performance

### DIFF
--- a/src/Configuration/features/revision/registry/configure-explorer-settings.yml
+++ b/src/Configuration/features/revision/registry/configure-explorer-settings.yml
@@ -146,6 +146,8 @@ actions:
   # === Force explorer to use high performance GPU
   - !registryValue: { path: 'HKCU\Software\Microsoft\DirectX\UserGpuPreferences', value: 'C:\Windows\explorer.exe', type: REG_SZ, data: 'GpuPreference=2;' }
 
+  # === Disable  "Include account-based insights, recent, favorite and recommended" for OneDrive in File Explorer
+  - !registryValue: { path: 'HKLM\SOFTWARE\Policies\Microsoft\Windows\Explorer', value: 'DisableGraphRecentItems', type: REG_DWORD, data: '1' }
 
     # ========================
     # === Discarded Tweaks ===

--- a/src/Configuration/features/revision/registry/configure-explorer-settings.yml
+++ b/src/Configuration/features/revision/registry/configure-explorer-settings.yml
@@ -143,6 +143,9 @@ actions:
   # ------> https://www.windowslatest.com/2024/03/04/windows-11-can-open-big-folders-in-file-explorer-faster-if-you-turn-off-folder-discovery/
   - !registryValue: {path: 'HKCU\SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\Shell\Bags\AllFolders\Shell', value: 'FolderType', type: REG_SZ, data: 'NotSpecified'} 
 
+  # === Force explorer to use high performance GPU
+  - !registryValue: { path: 'HKCU\Software\Microsoft\DirectX\UserGpuPreferences', value: 'C:\Windows\explorer.exe', type: REG_SZ, data: 'GpuPreference=2;' }
+
 
     # ========================
     # === Discarded Tweaks ===

--- a/src/Configuration/features/revision/registry/configure-explorer-settings.yml
+++ b/src/Configuration/features/revision/registry/configure-explorer-settings.yml
@@ -136,6 +136,14 @@ actions:
     # === Notify antivirus programs when opening attachments - Disabled
     # ------> Default is 3
   - !registryValue: {path: 'HKCU\Software\Microsoft\Windows\CurrentVersion\Policies\Attachments', value: 'ScanWithAntiVirus', type: REG_DWORD, data: '1'}
+
+
+  # === Disables Automatic Folder Type Discovery
+  # ------> Disabling it fixes the 'folder always loading' issue when a folder contains a lot of media files.  
+  # ------> https://www.windowslatest.com/2024/03/04/windows-11-can-open-big-folders-in-file-explorer-faster-if-you-turn-off-folder-discovery/
+  - !registryValue: {path: 'HKCU\SOFTWARE\Classes\Local Settings\Software\Microsoft\Windows\Shell\Bags\AllFolders\Shell', value: 'FolderType', type: REG_SZ, data: 'NotSpecified'} 
+
+
     # ========================
     # === Discarded Tweaks ===
     # ========================

--- a/src/Configuration/features/revision/registry/configure-explorer-settings.yml
+++ b/src/Configuration/features/revision/registry/configure-explorer-settings.yml
@@ -149,6 +149,34 @@ actions:
   # === Disable  "Include account-based insights, recent, favorite and recommended" for OneDrive in File Explorer
   - !registryValue: { path: 'HKLM\SOFTWARE\Policies\Microsoft\Windows\Explorer', value: 'DisableGraphRecentItems', type: REG_DWORD, data: '1' }
 
+  # ===  Disable Group By in the Downloads folder to avoid unnecessary dates comparison
+  - !powerShell: 
+    runas: trustedInstaller
+    command: |
+      $folderTypesKey = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\FolderTypes'
+      $downloadsFolderID = '{885a186e-a440-4ada-812b-db871b942259}'
+
+      $path = Join-Path -Path $folderTypesKey -ChildPath $downloadsFolderID
+      Get-ChildItem -Path $path -Recurse | ForEach-Object {
+        if ((Get-ItemProperty -Path $_.PSPath).GroupBy) {
+            Set-ItemProperty -Path $_.PSPath -Name GroupBy -Value ''
+          }
+      }
+    
+    # Necesarry to refresh 'Bags' to have an 
+  - !powerShell: 
+    runas: currentUserElevated
+    command: |
+      $downloadsFolderID = '{885a186e-a440-4ada-812b-db871b942259}'
+      $bagsPath = 'HKCU:\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\Bags'
+      Get-ChildItem -Path $bagsPath | ForEach-Object {
+        $fullPath = Join-Path -Path $_.PSPath -ChildPath 'Shell\{885A186E-A440-4ADA-812B-DB871B942259}'
+        if (Test-Path -Path $fullPath) {
+          Remove-Item -Path $fullPath -Recurse
+        } 
+      }
+
+
     # ========================
     # === Discarded Tweaks ===
     # ========================


### PR DESCRIPTION
- [Disable automatic folder type discovery](https://www.windowslatest.com/2024/03/04/windows-11-can-open-big-folders-in-file-explorer-faster-if-you-turn-off-folder-discovery/)
- Disable Group By in the Downloads folder
    - Reducing Date comparison helps to load the folder faster 
- Force explorer to use high performance GPU
    - Helps to load (media) thumbnails faster
-  (OneDrive) Disable "Include account-based insights, recent, favorite and recommended"