### PR TITLE
Make certain resources that are difficult to access in somewhere available offline

### DIFF
--- a/src/Configuration/features/revision/start.yml
+++ b/src/Configuration/features/revision/start.yml
@@ -58,7 +58,7 @@ actions:
   - !run: {exe: "powercfg", args: "/setactive scheme_current"}
 
   - !writeStatus: {status: 'Installing Revision Tool'}
-  - !powerShell: {command: "& { Invoke-WebRequest ((Invoke-RestMethod -Uri 'https://api.github.com/repos/meetrevision/revision-tool/releases/latest' -Method Get | ConvertTo-Json | ConvertFrom-Json).assets | where-object { $_.name -eq 'RevisionTool-Setup.exe' }).browser_download_url -OutFile \"$env:TEMP\\RevisionTool-Setup.exe\" }", errorAction: Halt, wait: true}
+  - !powerShell: {command: "& { if (-Not (Test-Path -Path C:\\RevisionTool-Setup.exe)) { Invoke-WebRequest ((Invoke-RestMethod -Uri 'https://api.github.com/repos/meetrevision/revision-tool/releases/latest' -Method Get | ConvertTo-Json | ConvertFrom-Json).assets | where-object { $_.name -eq 'RevisionTool-Setup.exe' }).browser_download_url -OutFile \"$env:TEMP\\RevisionTool-Setup.exe\" } else { Copy-Item -Force -Path C:\\RevisionTool-Setup.exe -Destination \"$env:TEMP\\RevisionTool-Setup.exe\" } }", errorAction: Halt, wait: true}
   - !cmd: {command: 'call "%temp%\RevisionTool-Setup.exe" /VERYSILENT /TASKS="desktopicon"', errorAction: Halt, wait: true, weight: 150}
 
   - !writeStatus: {status: "Optimizing PowerShell"}

--- a/src/Executables/UPDATE-APPX.ps1
+++ b/src/Executables/UPDATE-APPX.ps1
@@ -1,6 +1,12 @@
 Write-Host 'Updating Microsoft Store apps...'
 Write-Host 'Installing Winget Source'
-Add-AppPackage 'https://cdn.winget.microsoft.com/cache/source.msix' -ForceApplicationShutdown -Verbose
+
+if (-Not (Test-Path -Path 'C:\winget.msix')) {
+    Add-AppPackage 'https://cdn.winget.microsoft.com/cache/source.msix' -ForceApplicationShutdown -Verbose
+} else {
+    Add-AppPackage 'C:\winget.msix' -ForceApplicationShutdown -Verbose
+}
+
 $productName = (Get-ItemProperty -Path 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion').ProductName
 Write-Host "Product Name: $productName"
 $path = Join-Path ${env:ProgramFiles(x86)} 'Revision Tool'


### PR DESCRIPTION
#72 

These changes allow users to place dependent files in a specific location prior to deployment to avoid extremely slow networks that can cause deployments to get stuck

```
C:\RevisonTool-Setup.exe
C:\winget.msix
```