### PR TITLE
Fix the issue #133 

### DIFF
--- a/src/Configuration/Tasks/final.yml
+++ b/src/Configuration/Tasks/final.yml
@@ -113,3 +113,12 @@ actions:
     args: "playbook-patches apply"
     wait: true
     runas: currentUserElevated
+    
+  - !powerShell:
+    command: |
+      $explorerProcess = Get-Process -Name explorer -ErrorAction SilentlyContinue
+      if ($explorerProcess) {
+        Stop-Process -Name explorer -Force
+      }
+      Start-Process explorer
+    runas: currentUserElevated


### PR DESCRIPTION
Hello,

I have added functionality to restart Explorer after all the steps in the playbook have been completed. Please take a moment to review the code.

Additionally, I included a check to determine if Explorer is running, in order to close it. While I believe it’s possible to remove the -Force flag, I wanted to ensure with certainty that Explorer is fully closed before restarting it.

I have tested the playbook with this new addition, and everything is functioning as expected.

Best regards,
NextWorks