### PR TITLE
[FIX] Restore `VCLibs` framework to prevent infinite `wsappx` CPU loop

### DIFF
--- a/src/Configuration/Tasks/packages/appx.yml
+++ b/src/Configuration/Tasks/packages/appx.yml
@@ -120,7 +120,7 @@ actions:
     errorAction: Ignore
     weight: 20
     command: >-
-      $urls = @('https://aka.ms/Microsoft.VCLibs.x64.14.00.appx', 'https://aka.ms/Microsoft.VCLibs.x86.14.00.appx');
+      $urls = @('https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx', 'https://aka.ms/Microsoft.VCLibs.x86.14.00.Desktop.appx');
       foreach ($url in $urls) {
           $file = "$env:TEMP\$(Split-Path $url -Leaf)";
           Invoke-WebRequest -Uri $url -OutFile $file -UseBasicParsing;

--- a/src/Configuration/Tasks/packages/appx.yml
+++ b/src/Configuration/Tasks/packages/appx.yml
@@ -112,3 +112,18 @@ actions:
         'Microsoft.YourPhone',
         'MicrosoftWindows.CrossDevice'
       )
+
+  - !writeStatus: {status: "Restoring VCLibs"}
+  - !powerShell:
+    wait: true
+    exeDir: true
+    errorAction: Ignore
+    weight: 20
+    command: >-
+      $urls = @('https://aka.ms/Microsoft.VCLibs.x64.14.00.appx', 'https://aka.ms/Microsoft.VCLibs.x86.14.00.appx');
+      foreach ($url in $urls) {
+          $file = "$env:TEMP\$(Split-Path $url -Leaf)";
+          Invoke-WebRequest -Uri $url -OutFile $file -UseBasicParsing;
+          Add-AppxPackage -Path $file;
+          Remove-Item -Path $file -Force -ErrorAction SilentlyContinue;
+      }

--- a/src/Configuration/Tasks/packages/appx.yml
+++ b/src/Configuration/Tasks/packages/appx.yml
@@ -114,16 +114,53 @@ actions:
       )
 
   - !writeStatus: {status: "Restoring VCLibs"}
+
+  # === x64 Environment ===
+  - !download:
+    url: 'https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx'
+    destination: 'Microsoft.VCLibs.x64.14.00.Desktop.appx'
+    cpuArch: X64
   - !powerShell:
     wait: true
     exeDir: true
     errorAction: Ignore
-    weight: 20
-    command: >-
-      $urls = @('https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx', 'https://aka.ms/Microsoft.VCLibs.x86.14.00.Desktop.appx');
-      foreach ($url in $urls) {
-          $file = "$env:TEMP\$(Split-Path $url -Leaf)";
-          Invoke-WebRequest -Uri $url -OutFile $file -UseBasicParsing;
-          Add-AppxPackage -Path $file;
-          Remove-Item -Path $file -Force -ErrorAction SilentlyContinue;
-      }
+    cpuArch: X64
+    weight: 10
+    command: "Add-AppxPackage -Path '.\\Microsoft.VCLibs.x64.14.00.Desktop.appx'"
+
+  - !download:
+    url: 'https://aka.ms/Microsoft.VCLibs.x86.14.00.Desktop.appx'
+    destination: 'Microsoft.VCLibs.x86.14.00.Desktop.appx'
+    cpuArch: X64
+  - !powerShell:
+    wait: true
+    exeDir: true
+    errorAction: Ignore
+    cpuArch: X64
+    weight: 10
+    command: "Add-AppxPackage -Path '.\\Microsoft.VCLibs.x86.14.00.Desktop.appx'"
+
+  # === ARM64 Environment ===
+  - !download:
+    url: 'https://aka.ms/Microsoft.VCLibs.arm64.14.00.Desktop.appx'
+    destination: 'Microsoft.VCLibs.arm64.14.00.Desktop.appx'
+    cpuArch: Arm64
+  - !powerShell:
+    wait: true
+    exeDir: true
+    errorAction: Ignore
+    cpuArch: Arm64
+    weight: 10
+    command: "Add-AppxPackage -Path '.\\Microsoft.VCLibs.arm64.14.00.Desktop.appx'"
+
+  - !download:
+    url: 'https://aka.ms/Microsoft.VCLibs.arm.14.00.Desktop.appx'
+    destination: 'Microsoft.VCLibs.arm.14.00.Desktop.appx'
+    cpuArch: Arm64
+  - !powerShell:
+    wait: true
+    exeDir: true
+    errorAction: Ignore
+    cpuArch: Arm64
+    weight: 10
+    command: "Add-AppxPackage -Path '.\\Microsoft.VCLibs.arm.14.00.Desktop.appx'"

--- a/src/Configuration/Tasks/packages/appx.yml
+++ b/src/Configuration/Tasks/packages/appx.yml
@@ -113,9 +113,11 @@ actions:
         'MicrosoftWindows.CrossDevice'
       )
 
+
+  # https://github.com/meetrevision/playbook/issues/219
   - !writeStatus: {status: "Restoring VCLibs"}
 
-  # === x64 Environment ===
+  # x64
   - !download:
     url: 'https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx'
     destination: 'Microsoft.VCLibs.x64.14.00.Desktop.appx'
@@ -140,7 +142,7 @@ actions:
     weight: 10
     command: "Add-AppxPackage -Path '.\\Microsoft.VCLibs.x86.14.00.Desktop.appx'"
 
-  # === ARM64 Environment ===
+  # ARM64
   - !download:
     url: 'https://aka.ms/Microsoft.VCLibs.arm64.14.00.Desktop.appx'
     destination: 'Microsoft.VCLibs.arm64.14.00.Desktop.appx'


### PR DESCRIPTION
## Description

### Issue:
- #219
After applying the playbook on Windows 10 LTSC 21H2, the `wsappx` service group gets stuck in an infinite deployment loop. This happens because the ReviOS optimization aggressively strips unused AppX packages, which inadvertently orphans the `MicrosoftWindows.Client.CBS` package by removing its core dependency: the C++ Runtime framework (`Microsoft.VCLibs.140.00`). `AppXSvc` repeatedly attempts to stage/register the package, resulting in persistent 2-3% CPU usage on a single thread.

### Fix:
Appended a restoration step to the end of `playbook/src/Configuration/Tasks/packages/appx.yml` that explicitly reinstalls the required versions of `Microsoft.VCLibs.140.00` from Microsoft's official endpoints. 

Based on @melo936's feedback, this is handled using the AME Wizard's native `!download` action. This allows the dependencies to be resolved and cached during playbook compilation, ensuring support for fully offline deployments. Architecture-specific logic (`cpuArch`) ensures the correct x64/x86 or ARM64/ARM version is downloaded and installed via a subsequent PowerShell command.

By restoring these dependencies, `AppXSvc` is able to successfully evaluate the `Client.CBS` package and immediately spin down, returning CPU usage to 0%. 

## Changes Made
* Modified `playbook/src/Configuration/Tasks/packages/appx.yml` to include a `VCLibs` restoration step at the end of the AppX removal phase.
* Utilized the `!download` action instead of `Invoke-WebRequest` to allow for offline playbook application.
* Added `cpuArch: X64` and `cpuArch: Arm64` conditionals to correctly support both architectures.

## Impact & Testing
* **Performance:** Resolves the indefinite 2-3% CPU usage drain caused by `wsappx`.
* **Compatibility:** Fully safe for both Windows 10 LTSC and Windows 11. Ensuring `Client.CBS` has its dependencies met prevents breaking changes in Windows 11 (which heavily relies on this package for the Start Menu/Taskbar) while fixing the CPU loop on Windows 10.
* **Environments:** Fully supports offline environments and ARM64 hardware.

Resolves: #219