### PR TITLE
[FEATURE] Silence Windows Defender sample submission prompt

### DIFF
--- a/src/Configuration/Tasks/registry/security/security.yml
+++ b/src/Configuration/Tasks/registry/security/security.yml
@@ -17,6 +17,9 @@ actions:
   # ------> https://docs.microsoft.com/en-us/windows/privacy/configure-windows-diagnostic-data-in-your-organization
   - !registryValue: {path: 'HKLM\Software\Policies\Microsoft\Windows Defender\Reporting', value: 'DisableGenericRePorts', type: REG_DWORD, data: '1'}
 
+  # === Disable Windows Defender sample submission nag
+  - !registryValue: {path: 'HKLM\Software\Policies\Microsoft\Windows Defender\Spynet', value: 'SubmitSamplesConsent', type: REG_DWORD, data: '2'}
+
   # ==================================================================
   # === Windows Defender Antivirus - Security Intelligence Updates ===
   # ==================================================================

--- a/src/Configuration/Tasks/revert.yml
+++ b/src/Configuration/Tasks/revert.yml
@@ -102,9 +102,6 @@ actions:
   
   - !registryValue: {path: 'HKLM\Software\Policies\Microsoft\Windows Defender\Signature Updates', value: 'DisableScheduledSignatureUpdateOnBattery', type: REG_DWORD, data: '1'}
 
-  # Revert Windows Defender Antivirus - Spynet/Sample Submission policy
-  - !registryKey: {path: 'HKLM\Software\Policies\Microsoft\Windows Defender\Spynet', operation: delete}
-
   # Default Auto Tray behavior
   - !registryValue: {path: 'HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer', value: 'EnableAutoTray', operation: delete}
 

--- a/src/Configuration/Tasks/revert.yml
+++ b/src/Configuration/Tasks/revert.yml
@@ -102,6 +102,9 @@ actions:
   
   - !registryValue: {path: 'HKLM\Software\Policies\Microsoft\Windows Defender\Signature Updates', value: 'DisableScheduledSignatureUpdateOnBattery', type: REG_DWORD, data: '1'}
 
+  # Revert Windows Defender Antivirus - Spynet/Sample Submission policy
+  - !registryKey: {path: 'HKLM\Software\Policies\Microsoft\Windows Defender\Spynet', operation: delete}
+
   # Default Auto Tray behavior
   - !registryValue: {path: 'HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer', value: 'EnableAutoTray', operation: delete}
 


### PR DESCRIPTION
## Description

### Issue:
- #200
Users who prefer to keep Windows Defender enabled for security are subjected to a constant nag notification asking to submit files to Microsoft. Defender ignores standard Windows notification settings for this prompt, leaving users with no native UI option to silence it without turning off Defender completely.

### Fix:
Added a registry tweak to configure the `SubmitSamplesConsent` Spynet policy. By setting this registry value to `2` ("Never send"), it effectively suppresses the sample submission prompt while allowing Windows Defender's core security features to remain active.

## Changes Made
* Modified `playbook/src/Configuration/Tasks/registry/security/security.yml` to include the `SubmitSamplesConsent` registry value under the Defender reporting section.

## Impact & Testing
* **User Experience:** Removes a persistent and annoying notification, improving the quality of life for users who choose to keep Defender enabled.
* **Security & Privacy:** Keeps Defender's real-time protection intact while safely preventing unwanted file sample uploads and telemetry.

Resolves: #200